### PR TITLE
Mirror perceptiq-preview Redis and GCP NLP secret wiring in perceptiq

### DIFF
--- a/layer0/apps/perceptiq/configmap.yaml
+++ b/layer0/apps/perceptiq/configmap.yaml
@@ -10,3 +10,6 @@ data:
   CLERK_ISSUER: "https://enhanced-raven-64.clerk.accounts.dev"
   CLERK_JWKS_URL: "https://enhanced-raven-64.clerk.accounts.dev/.well-known/jwks.json"
   VITE_CLERK_PUBLISHABLE_KEY: "pk_test_ZW5oYW5jZWQtcmF2ZW4tNjQuY2xlcmsuYWNjb3VudHMuZGV2JA"
+  REDIS_URL: "redis://redis:6379"
+  GOOGLE_APPLICATION_CREDENTIALS: "/etc/gcp/sa-key.json"
+  GOOGLE_CLOUD_PROJECT: "perceptiq"

--- a/layer0/apps/perceptiq/deployment.yaml
+++ b/layer0/apps/perceptiq/deployment.yaml
@@ -17,6 +17,10 @@ spec:
     spec:
       imagePullSecrets:
         - name: ghcr-pull-secret
+      volumes:
+        - name: gcp-sa-key
+          secret:
+            secretName: gcp-nlp
       containers:
         - name: perceptiq
           image: ghcr.io/s1monb/perceptiq:0.1.1
@@ -34,6 +38,10 @@ spec:
                 name: perceptiq-secrets
             - configMapRef:
                 name: perceptiq
+          volumeMounts:
+            - name: gcp-sa-key
+              mountPath: /etc/gcp
+              readOnly: true
           livenessProbe:
             httpGet:
               path: /api/health

--- a/layer0/apps/perceptiq/gcp-nlp-secret.yaml
+++ b/layer0/apps/perceptiq/gcp-nlp-secret.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: gcp-nlp
+  namespace: perceptiq
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    name: onepassword
+    kind: ClusterSecretStore
+  target:
+    name: gcp-nlp
+  data:
+    - secretKey: sa-key.json
+      remoteRef:
+        key: gcp-nlp
+        property: sa-key.json

--- a/layer0/apps/perceptiq/kustomization.yaml
+++ b/layer0/apps/perceptiq/kustomization.yaml
@@ -5,6 +5,8 @@ resources:
   - configmap.yaml
   - externalsecret.yaml
   - ghcr-pull-secret.yaml
+  - redis.yaml
+  - gcp-nlp-secret.yaml
   - postgres.yaml
   - deployment.yaml
   - service.yaml

--- a/layer0/apps/perceptiq/redis.yaml
+++ b/layer0/apps/perceptiq/redis.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: perceptiq
+  labels:
+    app: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          ports:
+            - containerPort: 6379
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: perceptiq
+spec:
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `layer0/apps/perceptiq/redis.yaml` to mirror the Redis deployment/service used by `perceptiq-preview`
- add `layer0/apps/perceptiq/gcp-nlp-secret.yaml` to mirror the sentiment score ExternalSecret (`gcp-nlp`)
- update `layer0/apps/perceptiq/kustomization.yaml` to include both new resources
- update `layer0/apps/perceptiq/configmap.yaml` to include:
  - `REDIS_URL: redis://redis:6379`
  - `GOOGLE_APPLICATION_CREDENTIALS: /etc/gcp/sa-key.json`
  - `GOOGLE_CLOUD_PROJECT: perceptiq`
- update `layer0/apps/perceptiq/deployment.yaml` to mount the `gcp-nlp` secret at `/etc/gcp` (same as preview)

## Validation
- compared manifests and wiring with `layer0/apps/perceptiq-preview/*`
- attempted local render validation, but `kustomize`/`kubectl` binaries are not available in this cloud environment
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ddaecd0d-3888-4aaa-a9ab-23fe096f6841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ddaecd0d-3888-4aaa-a9ab-23fe096f6841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

