### PR TITLE
Add self-hosted Sentry (Helm) with ingress and 1Password secrets

### DIFF
--- a/layer0/apps-of-apps/sentry-config.yaml
+++ b/layer0/apps-of-apps/sentry-config.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: sentry-config
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+spec:
+  destination:
+    namespace: sentry
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: layer0/apps/sentry
+    repoURL: https://github.com/s1monb/homelab.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/layer0/apps-of-apps/sentry.yaml
+++ b/layer0/apps-of-apps/sentry.yaml
@@ -1,0 +1,85 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: sentry
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  destination:
+    namespace: sentry
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    chart: sentry
+    repoURL: https://sentry-kubernetes.github.io/charts
+    targetRevision: 29.5.1
+    helm:
+      releaseName: sentry
+      values: |
+        auth:
+          register: false
+
+        user:
+          create: true
+          email: admin@sentry.valley.no
+          existingSecret: sentry-secrets
+          existingSecretKey: admin-password
+
+        externalClickhouse:
+          host: sentry-clickhouse.sentry.svc.cluster.local
+          tcpPort: 9000
+          httpPort: 8123
+          username: default
+          database: default
+          singleNode: true
+          existingSecret: sentry-secrets
+          existingSecretKey: clickhouse-password
+
+        config:
+          configYml:
+            system.url: "https://sentry.valley.no"
+
+        ingress:
+          enabled: true
+          ingressClassName: cilium
+          hostname: sentry.valley.no
+          annotations:
+            cert-manager.io/cluster-issuer: letsencrypt-prod
+          tls:
+            - secretName: sentry-tls
+              hosts:
+                - sentry.valley.no
+
+        postgresql:
+          primary:
+            persistence:
+              storageClass: local-path
+              size: 20Gi
+
+        redis:
+          master:
+            persistence:
+              storageClass: local-path
+              size: 8Gi
+
+        kafka:
+          controller:
+            replicaCount: 1
+          provisioning:
+            replicationFactor: 1
+
+        filestore:
+          filesystem:
+            persistence:
+              storageClassName: local-path
+              size: 20Gi
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/layer0/apps/sentry/clickhouse.yaml
+++ b/layer0/apps/sentry/clickhouse.yaml
@@ -1,0 +1,80 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sentry-clickhouse
+  namespace: sentry
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  clusterIP: None
+  ports:
+    - name: http
+      port: 8123
+      targetPort: http
+    - name: native
+      port: 9000
+      targetPort: native
+  selector:
+    app: sentry-clickhouse
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: sentry-clickhouse
+  namespace: sentry
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  serviceName: sentry-clickhouse
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sentry-clickhouse
+  template:
+    metadata:
+      labels:
+        app: sentry-clickhouse
+    spec:
+      containers:
+        - name: clickhouse
+          image: clickhouse/clickhouse-server:24.8-alpine
+          ports:
+            - name: http
+              containerPort: 8123
+            - name: native
+              containerPort: 9000
+          env:
+            - name: CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT
+              value: "1"
+            - name: CLICKHOUSE_USER
+              value: default
+            - name: CLICKHOUSE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: sentry-secrets
+                  key: clickhouse-password
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/clickhouse
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              memory: 4Gi
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: local-path
+        resources:
+          requests:
+            storage: 50Gi

--- a/layer0/apps/sentry/externalsecret.yaml
+++ b/layer0/apps/sentry/externalsecret.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: sentry-secrets
+  namespace: sentry
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    name: onepassword
+    kind: ClusterSecretStore
+  target:
+    name: sentry-secrets
+  data:
+    - secretKey: admin-password
+      remoteRef:
+        key: sentry
+        property: password
+    - secretKey: clickhouse-password
+      remoteRef:
+        key: sentry
+        property: clickhouse-password

--- a/layer0/apps/sentry/kustomization.yaml
+++ b/layer0/apps/sentry/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - externalsecret.yaml
+  - clickhouse.yaml


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Deploy [Sentry Helm chart](https://artifacthub.io/packages/helm/sentry/sentry) via the app-of-apps pattern, expose the UI at `https://sentry.valley.no`, and source admin and ClickHouse credentials from 1Password through External Secrets (same pattern as Grafana).

## Changes

- **`layer0/apps-of-apps/sentry-config.yaml`** — Argo CD Application for `layer0/apps/sentry` (sync-wave before the Helm app).
- **`layer0/apps/sentry/`** — `ExternalSecret` for namespace `sentry`, plus a single-node ClickHouse StatefulSet (the chart requires external ClickHouse).
- **`layer0/apps-of-apps/sentry.yaml`** — Argo CD Application for chart `sentry` 29.5.1 from `https://sentry-kubernetes.github.io/charts`, with ingress (`ingressClassName: cilium`, cert-manager), `system.url`, and persistence on `local-path`. Kafka is reduced to one controller and replication factor 1 for a small cluster.

## 1Password / External Secrets

Create or extend a 1Password item referenced as **`sentry`** (matching `remoteRef.key: sentry`) with:

| Field | Maps to Kubernetes key |
|-------|-------------------------|
| `password` | `admin-password` (Sentry superuser) |
| `clickhouse-password` | `clickhouse-password` (default ClickHouse user) |

The superuser email is fixed in Helm values as `admin@sentry.valley.no` (login email). Adjust in `sentry.yaml` if you prefer a different address.

## Notes

- First sync can take a long time (many pods, hooks). If hooks time out, consider increasing `hooks.activeDeadlineSeconds` in chart values.
- Sentry is resource-heavy; you may need to tune requests/limits or scale Kafka/ClickHouse later.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1990ed74-869b-4a40-9118-d7484815bff1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1990ed74-869b-4a40-9118-d7484815bff1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

