### PR TITLE
Add OPENAI_API_KEY for Perceptiq preview and prod from shared 1Password secret

### DIFF
--- a/layer0/apps/perceptiq-preview/externalsecret.yaml
+++ b/layer0/apps/perceptiq-preview/externalsecret.yaml
@@ -19,3 +19,7 @@ spec:
       remoteRef:
         key: perceptiq-testing
         property: APIFY_TOKEN
+    - secretKey: OPENAI_API_KEY
+      remoteRef:
+        key: perceptiq
+        property: OPENAI_API_KEY

--- a/layer0/apps/perceptiq/externalsecret.yaml
+++ b/layer0/apps/perceptiq/externalsecret.yaml
@@ -19,3 +19,7 @@ spec:
       remoteRef:
         key: perceptiq
         property: APIFY_TOKEN
+    - secretKey: OPENAI_API_KEY
+      remoteRef:
+        key: perceptiq
+        property: OPENAI_API_KEY


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add `OPENAI_API_KEY` to the `perceptiq-secrets` ExternalSecret for **prod** (`layer0/apps/perceptiq`), sourced from the existing `perceptiq` 1Password item.
- Add the same key for **preview** (`layer0/apps/perceptiq-preview`), with `remoteRef.key: perceptiq` so preview and prod both read the **same** 1Password item/field (shared secret), while other preview keys remain on `perceptiq-testing`.

Deployments already use `envFrom: secretRef: perceptiq-secrets`, so the new key appears automatically as the `OPENAI_API_KEY` environment variable.

## Follow-up (manual)

Add an `OPENAI_API_KEY` field to the `perceptiq` item in 1Password if it is not already present; otherwise External Secrets will fail to sync until the field exists.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-200a8edb-44bc-4963-bc07-7c757ebb2ac2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-200a8edb-44bc-4963-bc07-7c757ebb2ac2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

