### PR TITLE
fix: increase hooks.activeDeadlineSeconds for sentry-snuba-migrate job

### DIFF
--- a/layer0/apps-of-apps/sentry.yaml
+++ b/layer0/apps-of-apps/sentry.yaml
@@ -19,6 +19,9 @@ spec:
     helm:
       releaseName: sentry
       values: |
+        hooks:
+          activeDeadlineSeconds: 600
+
         auth:
           register: false
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The `sentry-snuba-migrate` job hook was failing because it exceeded the default `activeDeadlineSeconds` of 100 seconds. This is a [known issue](https://github.com/sentry-kubernetes/charts/issues/712) with the Sentry Helm chart where the snuba migration needs more time than the default allows.

## Solution

Added `hooks.activeDeadlineSeconds: 600` (10 minutes) to the Sentry Helm values in the ArgoCD Application manifest. This gives the snuba migration job enough time to complete successfully.

## Changes

- `layer0/apps-of-apps/sentry.yaml`: Added `hooks.activeDeadlineSeconds: 600` to the inline Helm values
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-49ba4103-27d3-4d8e-9124-52e8a6a59fa0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49ba4103-27d3-4d8e-9124-52e8a6a59fa0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

