### PR TITLE
Add ollama operator and gemma4:32b model

### DIFF
--- a/layer0/apps-of-apps/ollama-operator.yaml
+++ b/layer0/apps-of-apps/ollama-operator.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ollama-operator
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: ollama-operator-system
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    repoURL: https://github.com/nekomeowww/ollama-operator.git
+    path: dist
+    targetRevision: v0.10.10
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/layer0/apps-of-apps/ollama.yaml
+++ b/layer0/apps-of-apps/ollama.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ollama
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: ollama
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: layer0/apps/ollama
+    repoURL: https://github.com/s1monb/homelab.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/layer0/apps/ollama/gemma4-32b.yaml
+++ b/layer0/apps/ollama/gemma4-32b.yaml
@@ -1,0 +1,7 @@
+apiVersion: ollama.ayaka.io/v1
+kind: Model
+metadata:
+  name: gemma4-32b
+  namespace: ollama
+spec:
+  image: gemma4:32b

--- a/layer0/apps/ollama/kustomization.yaml
+++ b/layer0/apps/ollama/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - gemma4-32b.yaml

--- a/layer0/apps/ollama/namespace.yaml
+++ b/layer0/apps/ollama/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ollama


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the [ollama-operator](https://github.com/nekomeowww/ollama-operator) to the homelab cluster and deploys the `gemma4:32b` model.

## Changes

### Argo CD Applications (`layer0/apps-of-apps/`)

- **`ollama-operator.yaml`** — Installs the ollama-operator (v0.10.10) from the upstream GitHub repository into the `ollama-operator-system` namespace. Uses `ServerSideApply=true` for CRD compatibility.
- **`ollama.yaml`** — Syncs the ollama model definitions from `layer0/apps/ollama` into the `ollama` namespace.

### App Manifests (`layer0/apps/ollama/`)

- **`namespace.yaml`** — Creates the `ollama` namespace.
- **`gemma4-32b.yaml`** — Deploys the `gemma4:32b` model using the ollama-operator `Model` CRD (`ollama.ayaka.io/v1`).
- **`kustomization.yaml`** — Kustomize entrypoint referencing the namespace and model resources.

## How It Works

1. Argo CD syncs the ollama-operator from the upstream `dist/` directory at tag `v0.10.10`, installing the controller and CRDs.
2. A separate Argo CD Application syncs the `Model` CR for `gemma4:32b`, which the operator picks up to pull and serve the model.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bdcbdda7-e12e-47d2-ad5c-c1d56572086e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bdcbdda7-e12e-47d2-ad5c-c1d56572086e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

