### PR TITLE
Fix Ollama operator deployment by replacing deprecated kube-rbac-proxy image source

### DIFF
--- a/layer0/apps-of-apps/ollama-operator.yaml
+++ b/layer0/apps-of-apps/ollama-operator.yaml
@@ -11,9 +11,9 @@ spec:
     server: https://kubernetes.default.svc
   project: default
   source:
-    repoURL: https://github.com/nekomeowww/ollama-operator.git
-    path: dist
-    targetRevision: v0.10.10
+    repoURL: https://github.com/s1monb/homelab.git
+    path: layer0/apps/ollama-operator
+    targetRevision: main
   syncPolicy:
     automated:
       prune: true

--- a/layer0/apps/ollama-operator/kustomization.yaml
+++ b/layer0/apps/ollama-operator/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/nekomeowww/ollama-operator/releases/download/v0.10.10/install.yaml
+images:
+  - name: gcr.io/kubebuilder/kube-rbac-proxy
+    newName: registry.k8s.io/kubebuilder/kube-rbac-proxy
+    newTag: v0.15.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- switch the `ollama-operator` Argo CD app to deploy from this repo instead of directly from upstream `dist`
- add a local kustomization at `layer0/apps/ollama-operator` that references upstream `install.yaml`
- override `gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0` to `registry.k8s.io/kubebuilder/kube-rbac-proxy:v0.15.0`

## Why
`gcr.io/kubebuilder/kube-rbac-proxy` is deprecated/unavailable, causing pulls to fail and preventing `ollama-operator` from deploying.

## Scope
- `layer0/apps-of-apps/ollama-operator.yaml`
- `layer0/apps/ollama-operator/kustomization.yaml`

## Notes
This keeps upstream operator manifests intact while applying only the image source fix needed for successful pulls.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7a434a5-d642-476d-a0d1-a46b4772ca22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7a434a5-d642-476d-a0d1-a46b4772ca22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

