### PR TITLE
feat(perceptiq): deploy the worker fleet

### DIFF
--- a/layer0/apps/argocd/perceptiq-image-updater.yaml
+++ b/layer0/apps/argocd/perceptiq-image-updater.yaml
@@ -14,3 +14,5 @@ spec:
       images:
         - alias: perceptiq
           imageName: ghcr.io/s1monb/perceptiq
+        - alias: workers
+          imageName: ghcr.io/s1monb/perceptiq-workers

--- a/layer0/apps/perceptiq/configmap.yaml
+++ b/layer0/apps/perceptiq/configmap.yaml
@@ -14,3 +14,8 @@ data:
   VITE_CLERK_PUBLISHABLE_KEY: "pk_test_ZW5oYW5jZWQtcmF2ZW4tNjQuY2xlcmsuYWNjb3VudHMuZGV2JA"
   GOOGLE_APPLICATION_CREDENTIALS: "/etc/gcp/sa-key.json"
   GOOGLE_CLOUD_PROJECT: "perceptiq"
+  # Worker fleet: each step is handled by its standalone worker instead of
+  # in-process. Keep in lockstep with the worker Deployments in workers.yaml.
+  FLEET_SENTIMENT_ENABLED: "true"
+  FLEET_THEME_ENABLED: "true"
+  FLEET_SCRAPER_ENABLED: "true"

--- a/layer0/apps/perceptiq/kustomization.yaml
+++ b/layer0/apps/perceptiq/kustomization.yaml
@@ -8,5 +8,6 @@ resources:
   - gcp-nlp-secret.yaml
   - postgres.yaml
   - deployment.yaml
+  - workers.yaml
   - service.yaml
   - ingress.yaml

--- a/layer0/apps/perceptiq/workers.yaml
+++ b/layer0/apps/perceptiq/workers.yaml
@@ -1,0 +1,151 @@
+# PerceptIQ worker fleet — one image, WORKER selects which worker runs.
+# Each binds its own durable NATS consumer and writes results straight to
+# Postgres; percept-api still owns the schema/migrations.
+#
+# These only receive work when the matching FLEET_* flag is set in the
+# perceptiq ConfigMap (otherwise the API does that step in-process).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: perceptiq-sentiment-worker
+  namespace: perceptiq
+  labels:
+    app: perceptiq-sentiment-worker
+    app.kubernetes.io/part-of: perceptiq-workers
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: perceptiq-sentiment-worker
+  template:
+    metadata:
+      labels:
+        app: perceptiq-sentiment-worker
+        app.kubernetes.io/part-of: perceptiq-workers
+    spec:
+      imagePullSecrets:
+        - name: ghcr-pull-secret
+      volumes:
+        - name: gcp-sa-key
+          secret:
+            secretName: gcp-nlp
+      containers:
+        - name: worker
+          image: ghcr.io/s1monb/perceptiq-workers:0.18.0
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: WORKER
+              value: sentiment
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: perceptiq-db-app
+                  key: uri
+          envFrom:
+            - secretRef:
+                name: perceptiq-secrets
+            - configMapRef:
+                name: perceptiq
+          volumeMounts:
+            - name: gcp-sa-key
+              mountPath: /etc/gcp
+              readOnly: true
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 384Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: perceptiq-theme-worker
+  namespace: perceptiq
+  labels:
+    app: perceptiq-theme-worker
+    app.kubernetes.io/part-of: perceptiq-workers
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: perceptiq-theme-worker
+  template:
+    metadata:
+      labels:
+        app: perceptiq-theme-worker
+        app.kubernetes.io/part-of: perceptiq-workers
+    spec:
+      imagePullSecrets:
+        - name: ghcr-pull-secret
+      containers:
+        - name: worker
+          image: ghcr.io/s1monb/perceptiq-workers:0.18.0
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: WORKER
+              value: theme
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: perceptiq-db-app
+                  key: uri
+          envFrom:
+            - secretRef:
+                name: perceptiq-secrets
+            - configMapRef:
+                name: perceptiq
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 384Mi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: perceptiq-scraper-worker
+  namespace: perceptiq
+  labels:
+    app: perceptiq-scraper-worker
+    app.kubernetes.io/part-of: perceptiq-workers
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: perceptiq-scraper-worker
+  template:
+    metadata:
+      labels:
+        app: perceptiq-scraper-worker
+        app.kubernetes.io/part-of: perceptiq-workers
+    spec:
+      imagePullSecrets:
+        - name: ghcr-pull-secret
+      containers:
+        - name: worker
+          image: ghcr.io/s1monb/perceptiq-workers:0.18.0
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: WORKER
+              value: scraper
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: perceptiq-db-app
+                  key: uri
+          envFrom:
+            - secretRef:
+                name: perceptiq-secrets
+            - configMapRef:
+                name: perceptiq
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi


### PR DESCRIPTION
Deploys the sentiment / theme / scraper workers and hands those pipeline steps over from the API.

## What
- **`workers.yaml`** — three Deployments from one image (`ghcr.io/s1monb/perceptiq-workers:0.18.0`), `WORKER` selects which runs. They reuse perceptiq's ConfigMap + Secret (NATS URL, OpenAI, Apify) and take `DATABASE_URL` from the CNPG app secret; the sentiment worker also mounts the GCP NLP key.
- **Flags flipped in lockstep** — `FLEET_SENTIMENT_ENABLED`, `FLEET_THEME_ENABLED`, `FLEET_SCRAPER_ENABLED`. The API stops publishing *and* consuming a step once its worker owns it (perceptiq#27), so each step has exactly one owner.
- **Image updater** tracks `perceptiq-workers` alongside the app, so the fleet follows the same semver.

## Verification
- `kustomize build` clean (12 resources).
- Confirmed the cluster can **pull the new GHCR package** with `ghcr-pull-secret` (ran a throwaway pod → `pull ok`) — package-scoped access was the main deployment risk.
- `PERCEPT_EVT` is currently empty, so the event-driven workers won't replay a backlog on first start.

## Risk to watch
The **scraper** worker is the least-exercised path: its lifecycle was verified end-to-end with Apify mocked and its transformers are parity-tested against the TS originals, but it has never made a real Apify actor call. If a live sync misbehaves, reverting is just `FLEET_SCRAPER_ENABLED: "false"` (the API resumes scraping inline); sentiment/theme are independent of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)